### PR TITLE
output jar path bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ local.properties
 proguard.cfg
 proguard-project.txt
 
+#Gradle
+.gradle
+
 #Other
 .DS_Store
 .tmp

--- a/jarjar-gradle-plugin/src/main/groovy/net/vrallev/gradle/jarjar/JarJarPlugin.groovy
+++ b/jarjar-gradle-plugin/src/main/groovy/net/vrallev/gradle/jarjar/JarJarPlugin.groovy
@@ -113,6 +113,7 @@ class JarJarPlugin implements Plugin<Project> {
     }
 
     public static File getResultFile(Project project) {
-        return new File(project.projectDir.name + File.separatorChar + getExtension(project).outputDir, getExtension(project).outputName)
+        def ext = getExtension(project)
+        return new File(project.projectDir, "$ext.outputDir$File.separator$ext.outputName")
     }
 }


### PR DESCRIPTION
There was a minor bug in JarJarPlugin.getResultFile() which resulted in building a path with redundant components.  I made a change so the outputDir is always relative to the projectDir.  I also added the .gradle/ dir to the .gitignore file.
